### PR TITLE
Add "M-Audio Axiom AIR Mini 32" controller mapping

### DIFF
--- a/resource/userdata_original/controllers/Axiom AIR Mini 32 MIDI In.json
+++ b/resource/userdata_original/controllers/Axiom AIR Mini 32 MIDI In.json
@@ -1,0 +1,76 @@
+{
+
+ "groups" : [
+      {
+       "rows": 1,
+       "cols": 1,
+       "position" : [ 26, 0 ],
+       "dimensions" : [20, 20],
+       "spacing" : [26, 26],
+       "controls" : [19],
+       "messageType" : "control",
+       "drawType" : "button"
+      },
+      {
+       "rows": 1,
+       "cols": 3,
+       "position" : [ 0, 30 ],
+       "dimensions" : [20, 20],
+       "spacing" : [26, 26],
+       "controls" : [22,23,21],
+       "messageType" : "control",
+       "drawType" : "button"
+      },
+      {
+       "rows": 1,
+       "cols": 1,
+       "position" : [ 26, 60 ],
+       "dimensions" : [20, 20],
+       "spacing" : [26, 26],
+       "controls" : [20],
+       "messageType" : "control",
+       "drawType" : "button"
+      },
+      { 
+         "rows": 2,
+         "cols": 4,
+         "position" : [ 90, 0 ],
+         "dimensions" : [28, 28],
+         "spacing" : [30, 30],
+         "controls" : [1,2,3,4,5,6,7,8],
+         "messageType" : "control",
+         "drawType" : "knob",
+         "incremental" : false
+      },
+      {
+		 "rows": 1,
+		 "cols": 3,
+		 "position" : [ 106, 68 ],
+		 "dimensions" : [25, 20],
+		 "spacing" : [30, 30],
+		 "controls" : [16,17,18],
+		 "messageType" : "control",
+		 "drawType" : "button"
+      },
+ {
+		 "rows": 2,
+         "cols": 4,
+         "position" : [ 84, 110 ],
+         "dimensions" : [28, 28],
+         "spacing" : [30, 30],
+         "controls" : [40,41,42,43,36,37,38,39],
+         "messageType" : "note",
+         "drawType" : "button"
+      },
+      {
+         "rows": 2,
+         "cols": 4,
+         "position" : [ 84, 182 ],
+         "dimensions" : [28, 28],
+         "spacing" : [30, 30],
+         "controls" : [48,49,50,51,44,45,46,47],
+         "messageType" : "note",
+         "drawType" : "button"
+     }
+   ]
+}


### PR DESCRIPTION
Here is the mapping layout for the "M-Audio Axiom AIR Mini 32".

![Axiom_Air_Mini_Layout](https://user-images.githubusercontent.com/92523279/139527460-10e4fe95-3a46-4659-aca3-5acf56949f6a.png)
